### PR TITLE
Init virtio-mmio devices with custom register + irqnum

### DIFF
--- a/arch/src/aarch64/gic/gicv3.rs
+++ b/arch/src/aarch64/gic/gicv3.rs
@@ -12,6 +12,7 @@ pub mod kvm {
         construct_gicr_typers, get_redist_regs, set_redist_regs,
     };
     use crate::aarch64::gic::GicDevice;
+    use crate::aarch64::*;
     use crate::layout;
     use anyhow::anyhow;
     use hypervisor::kvm::kvm_bindings;
@@ -83,7 +84,7 @@ pub mod kvm {
 
         /// Get the address of the GIC distributor.
         pub fn get_dist_addr() -> u64 {
-            layout::GIC_V3_DIST_START
+            get_gic_dist_addr()
         }
 
         /// Get the size of the GIC distributor.
@@ -93,12 +94,12 @@ pub mod kvm {
 
         /// Get the address of the GIC redistributors.
         pub fn get_redists_addr(vcpu_count: u64) -> u64 {
-            KvmGicV3::get_dist_addr() - KvmGicV3::get_redists_size(vcpu_count)
+            get_gic_redists_addr()
         }
 
         /// Get the size of the GIC redistributors.
         pub fn get_redists_size(vcpu_count: u64) -> u64 {
-            vcpu_count * layout::GIC_V3_REDIST_SIZE
+            get_gic_redists_size()
         }
 
         /// Save the state of GIC.

--- a/arch/src/aarch64/gic/gicv3_its.rs
+++ b/arch/src/aarch64/gic/gicv3_its.rs
@@ -13,6 +13,7 @@ pub mod kvm {
     use crate::aarch64::gic::gicv3::kvm::KvmGicV3;
     use crate::aarch64::gic::kvm::{save_pending_tables, KvmGicDevice};
     use crate::aarch64::gic::GicDevice;
+    use crate::aarch64::*;
     use crate::layout;
     use anyhow::anyhow;
     use hypervisor::kvm::kvm_bindings;
@@ -185,7 +186,7 @@ pub mod kvm {
         }
 
         fn get_msi_addr(vcpu_count: u64) -> u64 {
-            KvmGicV3::get_redists_addr(vcpu_count) - KvmGicV3Its::get_msi_size()
+            get_gic_its_addr()
         }
 
         /// Save the state of GICv3ITS.

--- a/arch/src/aarch64/gic/mod.rs
+++ b/arch/src/aarch64/gic/mod.rs
@@ -76,6 +76,7 @@ pub trait GicDevice: Send {
 pub mod kvm {
     use super::GicDevice;
     use super::Result;
+    use crate::aarch64::gic::gicv3::kvm::KvmGicV3;
     use crate::aarch64::gic::gicv3_its::kvm::KvmGicV3Its;
     use crate::layout;
     use hypervisor::kvm::kvm_bindings;
@@ -199,9 +200,19 @@ pub mod kvm {
 
     /// Create a GICv3-ITS device.
     ///
-    pub fn create_gic(vm: &Arc<dyn hypervisor::Vm>, vcpu_count: u64) -> Result<Box<dyn GicDevice>> {
+    pub fn create_gic_its(
+        vm: &Arc<dyn hypervisor::Vm>,
+        vcpu_count: u64,
+    ) -> Result<Box<dyn GicDevice>> {
         debug!("creating a GICv3-ITS");
         KvmGicV3Its::new(vm, vcpu_count)
+    }
+
+    /// Create a GICv3 device.
+    ///
+    pub fn create_gic(vm: &Arc<dyn hypervisor::Vm>, vcpu_count: u64) -> Result<Box<dyn GicDevice>> {
+        debug!("creating a GICv3");
+        KvmGicV3::new(vm, vcpu_count)
     }
 
     /// Function that saves RDIST pending tables into guest RAM.

--- a/arch/src/aarch64/mod.rs
+++ b/arch/src/aarch64/mod.rs
@@ -200,6 +200,10 @@ pub fn initramfs_load_addr(
 static mut KERNEL_START: u64 = layout::KERNEL_START;
 static mut RAM_64BIT_START: u64 = layout::RAM_64BIT_START;
 static mut FDT_START: u64 = layout::FDT_START;
+static mut GIC_V3_DIST_START: u64 = layout::GIC_V3_DIST_START;
+static mut GIC_V3_REDISTS_ADDR: u64 = layout::GIC_V3_DIST_START - layout::GIC_V3_REDIST_SIZE;
+static mut GIC_V3_REDISTS_SIZE: u64 = layout::GIC_V3_REDIST_SIZE;
+static mut GIC_V3_ITS_ADDR: u64 = unsafe{GIC_V3_REDISTS_ADDR - layout::GIC_V3_ITS_SIZE};
 
 pub fn set_kernel_start(start: u64) {
     unsafe {
@@ -216,6 +220,30 @@ pub fn set_ram_start(start: u64) {
 pub fn set_fdt_addr(addr: u64) {
     unsafe {
         FDT_START = addr;
+    };
+}
+
+pub fn set_gic_dist_addr(addr: u64) {
+    unsafe {
+        GIC_V3_DIST_START = addr;
+    };
+}
+
+pub fn set_gic_redists_addr(addr: u64) {
+    unsafe {
+        GIC_V3_REDISTS_ADDR = addr;
+    };
+}
+
+pub fn set_gic_redists_size(addr: u64) {
+    unsafe {
+        GIC_V3_REDISTS_SIZE = addr;
+    };
+}
+
+pub fn set_gic_its_addr(addr: u64) {
+    unsafe {
+        GIC_V3_ITS_ADDR = addr;
     };
 }
 
@@ -236,6 +264,22 @@ pub fn get_uefi_start() -> u64 {
 // Auxiliary function to get the address where the device tree blob is loaded.
 fn get_fdt_addr() -> u64 {
     unsafe{FDT_START}
+}
+
+pub fn get_gic_dist_addr() -> u64 {
+    unsafe {GIC_V3_DIST_START}
+}
+
+pub fn get_gic_redists_addr() -> u64 {
+    unsafe {GIC_V3_REDISTS_ADDR}
+}
+
+pub fn get_gic_redists_size() -> u64 {
+    unsafe {GIC_V3_REDISTS_SIZE}
+}
+
+pub fn get_gic_its_addr() -> u64 {
+    unsafe {GIC_V3_ITS_ADDR}
 }
 
 pub fn get_host_cpu_phys_bits() -> u8 {

--- a/devices/src/gic.rs
+++ b/devices/src/gic.rs
@@ -17,7 +17,7 @@ type Result<T> = result::Result<T, Error>;
 
 // Reserve 32 IRQs for legacy device.
 pub const IRQ_LEGACY_BASE: usize = arch::layout::IRQ_BASE as usize;
-pub const IRQ_LEGACY_COUNT: usize = 32;
+pub const IRQ_LEGACY_COUNT: usize = 128;
 
 // This Gic struct implements InterruptController to provide interrupt delivery service.
 // The Gic source files in arch/ folder maintain the Aarch64 specific Gic device.

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -144,6 +144,28 @@ impl SystemAllocator {
         )
     }
 
+    /// Reserves a section of `size` bytes of platform MMIO or MMIO hole address space.
+    pub fn allocate_platform_or_mmio_hole_addresses(
+        &mut self,
+        address: Option<GuestAddress>,
+        size: GuestUsize,
+        align_size: Option<GuestUsize>,
+    ) -> Option<GuestAddress> {
+        let mmio_hole = self.mmio_hole_address_space.allocate(
+            address,
+            size,
+            Some(align_size.unwrap_or(pagesize() as u64)),
+        );
+        if mmio_hole.is_some() {
+            return mmio_hole;
+        }
+        self.platform_mmio_address_space.allocate(
+            address,
+            size,
+            Some(align_size.unwrap_or(pagesize() as u64)),
+        )
+    }
+
     #[cfg(target_arch = "x86_64")]
     /// Free an IO address range.
     /// We can only free a range if it matches exactly an already allocated range.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1290,7 +1290,10 @@ impl DeviceManager {
                 base: *mmio_base,
                 size: 0x200,
             });
-            node.resources.push(Resource::LegacyIrq(*irq_num));
+            /* Nuno: add IRQ_BASE, because what goes in the device tree is irq - IRQ_BASE...
+             * TODO: really we should add it in add_virtio_mmio_device but its here for now
+             */
+            node.resources.push(Resource::LegacyIrq(*irq_num + arch::IRQ_BASE));
             self.device_tree.lock().unwrap().insert(id, node);
         }
 

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3903,7 +3903,7 @@ impl DeviceManager {
             .push(Arc::clone(&mmio_device_arc) as Arc<Mutex<dyn BusDevice>>);
         self.address_manager
             .mmio_bus
-            .insert(mmio_device_arc.clone(), mmio_base, MMIO_LEN)
+            .insert(mmio_device_arc.clone(), mmio_base, mmio_size)
             .map_err(DeviceManagerError::BusError)?;
 
         #[cfg(target_arch = "x86_64")]

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3823,7 +3823,7 @@ impl DeviceManager {
                 .allocator
                 .lock()
                 .unwrap()
-                .allocate_platform_mmio_addresses(Some(GuestAddress(base)), size, Some(size))
+                .allocate_platform_or_mmio_hole_addresses(Some(GuestAddress(base)), size, Some(size))
                 .ok_or(DeviceManagerError::MmioRangeAllocation)?;
 
             (base, size)

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1191,7 +1191,7 @@ impl MemoryManager {
                 start_of_platform_device_area,
                 PLATFORM_DEVICE_AREA_SIZE,
                 layout::MEM_32BIT_DEVICES_START,
-                layout::MEM_32BIT_DEVICES_SIZE,
+                ram_start.unchecked_sub(layout::MEM_32BIT_DEVICES_START.0).0,
             )
             .ok_or(Error::CreateSystemAllocator)?,
         ));

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1104,13 +1104,25 @@ impl Vm {
             exit_evt,
         };
 
+        // TODO get these from device tree
+        // tuple of (address, irq)
+        let virtio_mmio_slots: Vec<(u64, u32)> = vec![
+            (0x4100_0000, 0x64),
+            (0x4100_0200, 0x65),
+            (0x4100_0400, 0x66),
+            (0x4100_0600, 0x67),
+            (0x4100_0800, 0x68),
+            (0x4100_0a00, 0x69),
+            (0x4100_0c00, 0x6a),
+            (0x4100_0e00, 0x6b),
+        ];
         // The device manager must create the devices from here as it is part
         // of the regular code path creating everything from scratch.
         new_vm
             .device_manager
             .lock()
             .unwrap()
-            .create_devices_craton(serial_pty, console_pty, console_resize_pipe, uio_devices_info)
+            .create_devices_craton(serial_pty, console_pty, console_resize_pipe, uio_devices_info, virtio_mmio_slots)
             .map_err(Error::DeviceManager)?;
 
         Ok(new_vm)


### PR DESCRIPTION
Init virtio-mmio devices from a list of 'slots' - pairs of address and irq number which we'll get from dtb

**(This doesn't work yet, hence draft)**

In add_virtio_mmio_devices, the mmio memory is reserved with the system allocator using allocate_platform_mmio_addresses() - because CLH normally allocates virtio devices in the 'platform device' area, above regular ram.
But, the virtio addresses we need to use, from the ARE device tree, are not in that area - they're below the ram, so the allocate fails.

So we need to get around this somehow, and it's not as simple as nudging the hardcoded layout around like before; we want to allocate the virtio devices in a completely different area than originally intended by CLH...

Simplest solution might be to change the add_virtio_mmio_code to try and allocate in platform device region, and if that fails, try mmio hole region (below ram), which would then succeed. I might try that and see if I run into anything else...